### PR TITLE
[testrail_apache] Fix incorrect cp for SSL in entrypoint

### DIFF
--- a/Dockerfiles/testrail_apache/custom-entrypoint.sh
+++ b/Dockerfiles/testrail_apache/custom-entrypoint.sh
@@ -22,7 +22,7 @@ then
     echo "####################################################"
     echo
 
-    cp -f /ssl_apache_testrail.conf /etc/apache2/sites-enabled/ssl_apache_testrail.conf
+    cp -f /apache-conf/ssl_apache_testrail.conf /etc/apache2/sites-enabled/ssl_apache_testrail.conf
 fi
 
 createOptDirectory $TR_DEFAULT_LOG_DIR


### PR DESCRIPTION
`ssl_apache_testrail.conf` is in `/apache-conf/`, but the command `cp` tried to copy it from `/`.

Therefore the following log was seen:

```
srv_1  | cp: cannot stat '/ssl_apache_testrail.conf': No such file or directory
```