### PR TITLE
Fix configuration when SSL is enabled.

### DIFF
--- a/Dockerfiles/testrail_apache/.htaccess
+++ b/Dockerfiles/testrail_apache/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine On
+RewriteCond %{HTTPS} off
+RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}

--- a/Dockerfiles/testrail_apache/Dockerfile
+++ b/Dockerfiles/testrail_apache/Dockerfile
@@ -62,6 +62,7 @@ VOLUME /etc/apache2/ssl
 
 COPY apache_testrail.conf /apache-conf/000-default.conf
 COPY ssl_apache_testrail.conf /apache-conf/ssl_apache_testrail.conf
+COPY .htaccess /apache-conf/.htaccess
 
 COPY custom-entrypoint.sh /custom-entrypoint.sh
 ENTRYPOINT ["/custom-entrypoint.sh"]

--- a/Dockerfiles/testrail_apache/custom-entrypoint.sh
+++ b/Dockerfiles/testrail_apache/custom-entrypoint.sh
@@ -22,6 +22,8 @@ then
     echo "####################################################"
     echo
 
+	# Enable SSL
+	a2enmod ssl
     cp -f /apache-conf/ssl_apache_testrail.conf /etc/apache2/sites-enabled/ssl_apache_testrail.conf
 fi
 

--- a/Dockerfiles/testrail_apache/custom-entrypoint.sh
+++ b/Dockerfiles/testrail_apache/custom-entrypoint.sh
@@ -25,6 +25,9 @@ then
 	# Enable SSL
 	a2enmod ssl
     cp -f /apache-conf/ssl_apache_testrail.conf /etc/apache2/sites-enabled/ssl_apache_testrail.conf
+	# Perform redirection from HTTP to HTTPS
+	a2enmod rewrite
+	cp -f /apache-conf/.htaccess /var/www/testrail/.htaccess
 fi
 
 createOptDirectory $TR_DEFAULT_LOG_DIR

--- a/Dockerfiles/testrail_apache/ssl_apache_testrail.conf
+++ b/Dockerfiles/testrail_apache/ssl_apache_testrail.conf
@@ -5,9 +5,9 @@
         DocumentRoot /var/www/testrail
 
         SSLEngine on
-        SSLCertificateFile /etc/apache2/ssl/certificate.crt;
-        SSLCertificateKeyFile /etc/apache2/ssl/cert_key.pem;
-        SSLCertificateChainFile /etc/apache2/ssl/certificate.crt;
+        SSLCertificateFile /etc/apache2/ssl/certificate.crt
+        SSLCertificateKeyFile /etc/apache2/ssl/key.pem
+        SSLCertificateChainFile /etc/apache2/ssl/certificate.crt
 
         ErrorLog ${APACHE_LOG_DIR}/ssl_error.log
         CustomLog ${APACHE_LOG_DIR}/ssl_access.log combined


### PR DESCRIPTION
There were several issues preventing one to successfully enable SSL:

- There were typos in `ssl_apache_testrail.conf` 
- The SSL apache module was not enabled, it should be done in the entrypoint.
- Virtualhost was not forcing redirection to HTTPS. Here, it is assumed that if a user enables SSL, he wants it to be the only way to access Testrail. See ebc4530 for more details.