### PR TITLE
Update docker-compose_documented.yml

### DIFF
--- a/docker-compose_documented.yml
+++ b/docker-compose_documented.yml
@@ -56,6 +56,7 @@ services:
     # if the variable 'HTTP_PORT' is not specified (it's actually a simple port forwarding what's done here).
     # The 'HTTP_PORT' environment variable can either be set in a .env file or as a variable directly in the shell.
     # Pls. have a look at our documentation for further information regarding environment variables.
+    # If using SSL, you should map an additional port here like - 80001:443
     ports:
       - "${HTTP_PORT:-8000}:80"
     volumes:


### PR DESCRIPTION
Without explicitly identifying a HTTPS port, you will encounter SSL_ERROR_RX_RECORD_TOO_LONG if just running the default docker-compose :)