### PR TITLE
Fix "Call to undefined funtion imagejpeg"

### DIFF
--- a/Dockerfiles/testrail_apache/Dockerfile
+++ b/Dockerfiles/testrail_apache/Dockerfile
@@ -40,7 +40,8 @@ RUN \
     docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu && \
     docker-php-ext-install ldap && \
     docker-php-ext-install pdo && \
-    docker-php-ext-install gd && \
+    docker-php-ext-configure gd --enable-gd --with-jpeg && \
+    docker-php-ext-install -j$(nproc) gd && \
     docker-php-ext-install pdo_mysql
 
 RUN \


### PR DESCRIPTION
This fixes the following erorr in the logs:
![image002](https://github.com/gurock/testrail-docker/assets/8343141/6f8e0996-70b2-4420-8773-d93b5d099a9b)

These happend when for example pasting an image in a textbox (field) while editing a test case:
![image001](https://github.com/gurock/testrail-docker/assets/8343141/b854e492-1ede-4cfe-a7a7-63fed687389a)

Also this fixes that the thumbnails on the right when viewing a testcase are not shown:
![image003](https://github.com/gurock/testrail-docker/assets/8343141/98b8a1bf-f4c4-4ae8-8576-4fc5ac94b0d3)

Note: The actual needed change was the `docker-php-ext-configure` line but I think it's okay to add `-j$(nproc)` for the gd install.

These changes seems necessary since updating PHP to 7.4 and newer, see:
- https://www.php.net/manual/en/image.installation.php
- https://stackoverflow.com/questions/69556122/unable-to-enable-gd-with-jpeg-support-in-php8-container-running-in-docker