### PR TITLE
Update Dockerfile GD installation with JPEG support

### DIFF
--- a/Dockerfiles/testrail_apache/Dockerfile
+++ b/Dockerfiles/testrail_apache/Dockerfile
@@ -40,7 +40,8 @@ RUN \
     docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu && \
     docker-php-ext-install ldap && \
     docker-php-ext-install pdo && \
-    docker-php-ext-install gd && \
+    docker-php-ext-configure gd --enable-gd --with-jpeg && \
+    docker-php-ext-install -j$(nproc) gd && \
     docker-php-ext-install pdo_mysql
 
 RUN \


### PR DESCRIPTION
This PR addresses an issue where broken image icons were displayed instead of thumbnails for uploaded attachments. The root cause was missing support for JPEG image processing within the GD extension.

**Changed:** We updated the dockerfile line to include JPEG support for the GD extension installation

[x] QE Passed in all functions for Testrail with images.