### PR TITLE
Add changes for chromium-based (headless) pdf generation for TR on Docker

### DIFF
--- a/Dockerfiles/testrail_apache/Dockerfile
+++ b/Dockerfiles/testrail_apache/Dockerfile
@@ -14,6 +14,7 @@ ENV TR_DEFAULT_ATTACHMENT_DIR="/opt/testrail/attachments/"
 ENV OPENSSL_CONF="/etc/ssl/"
 ENV LDAP_CONF_DIR="/etc/ldap/"
 ENV LDAP_CONF_FILE="$LDAP_CONF_DIR/ldap.conf"
+ENV TR_CHROMIUM_PATH="/usr/bin/chrome-headless-shell-linux64/chrome-headless-shell"
 
 LABEL vendor="TestRail" \
       maintainer="Christian Breitwieser" \

--- a/Dockerfiles/testrail_apache/Dockerfile
+++ b/Dockerfiles/testrail_apache/Dockerfile
@@ -98,6 +98,19 @@ RUN ( cd /tmp && \
       ./configure && \
       make install \
     )
+
+RUN ( cd /tmp && \
+      apt-get update && \
+      apt install -y libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxrandr2 libgbm-dev libasound2 libatk1.0-0 libatk-bridge2.0-0 libx11-dev libnss3 libnspr4 libxss1 libxext6 libxshmfence-dev libxkbcommon-dev && \
+      wget https://storage.googleapis.com/chrome-for-testing-public/131.0.6778.69/linux64/chrome-headless-shell-linux64.zip && \
+      unzip "chrome-headless-shell-linux64.zip" && \
+      mv chrome-headless-shell-linux64 /usr/bin && \
+      chown root:www-data /usr/bin/chrome-headless-shell-linux64/* -R && \
+      chown root:www-data /usr/bin/chrome-headless-shell-linux64 && \
+      chmod 775 /usr/bin/chrome-headless-shell-linux64/* -R && \
+      chmod 775 /usr/bin/chrome-headless-shell-linux64 \
+    )
+
 RUN rm -rf /tmp/php-driver
 RUN mkdir -p /apache-conf
 VOLUME /apache-conf

--- a/Dockerfiles/testrail_apache/Dockerfile
+++ b/Dockerfiles/testrail_apache/Dockerfile
@@ -103,7 +103,8 @@ RUN ( cd /tmp && \
 RUN ( cd /tmp && \
       apt-get update && \
       apt install -y libnss3 libatk1.0-0 libxcomposite1 libxdamage1 libxrandr2 libgbm1 libxkbcommon0 libasound2 libatk-bridge2.0-0 libxfixes3 && \
-      wget https://storage.googleapis.com/chrome-for-testing-public/131.0.6778.69/linux64/chrome-headless-shell-linux64.zip && \
+      LATEST_VERSION=$(wget -qO- https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_STABLE) && \
+      wget https://storage.googleapis.com/chrome-for-testing-public/${LATEST_VERSION}/linux64/chrome-headless-shell-linux64.zip && \
       unzip "chrome-headless-shell-linux64.zip" && \
       mv chrome-headless-shell-linux64 /usr/bin && \
       chown www-data:www-data /usr/bin/chrome-headless-shell-linux64/* -R && \

--- a/Dockerfiles/testrail_apache/Dockerfile
+++ b/Dockerfiles/testrail_apache/Dockerfile
@@ -14,7 +14,7 @@ ENV TR_DEFAULT_ATTACHMENT_DIR="/opt/testrail/attachments/"
 ENV OPENSSL_CONF="/etc/ssl/"
 ENV LDAP_CONF_DIR="/etc/ldap/"
 ENV LDAP_CONF_FILE="$LDAP_CONF_DIR/ldap.conf"
-ENV TR_CHROMIUM_PATH="/usr/bin/chrome-headless-shell-linux64/chrome-headless-shell"
+ENV TR_CHROME_PATH="/usr/bin/chrome-headless-shell-linux64/chrome-headless-shell"
 
 LABEL vendor="TestRail" \
       maintainer="Christian Breitwieser" \

--- a/Dockerfiles/testrail_apache/Dockerfile
+++ b/Dockerfiles/testrail_apache/Dockerfile
@@ -101,12 +101,12 @@ RUN ( cd /tmp && \
 
 RUN ( cd /tmp && \
       apt-get update && \
-      apt install -y libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxrandr2 libgbm-dev libasound2 libatk1.0-0 libatk-bridge2.0-0 libx11-dev libnss3 libnspr4 libxss1 libxext6 libxshmfence-dev libxkbcommon-dev && \
+      apt install -y libnss3 libatk1.0-0 libxcomposite1 libxdamage1 libxrandr2 libgbm1 libxkbcommon0 libasound2 libatk-bridge2.0-0 libxfixes3 && \
       wget https://storage.googleapis.com/chrome-for-testing-public/131.0.6778.69/linux64/chrome-headless-shell-linux64.zip && \
       unzip "chrome-headless-shell-linux64.zip" && \
       mv chrome-headless-shell-linux64 /usr/bin && \
-      chown root:www-data /usr/bin/chrome-headless-shell-linux64/* -R && \
-      chown root:www-data /usr/bin/chrome-headless-shell-linux64 && \
+      chown www-data:www-data /usr/bin/chrome-headless-shell-linux64/* -R && \
+      chown www-data:www-data /usr/bin/chrome-headless-shell-linux64 && \
       chmod 775 /usr/bin/chrome-headless-shell-linux64/* -R && \
       chmod 775 /usr/bin/chrome-headless-shell-linux64 \
     )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@
 # Instructions for necessary settings during setup when using docker-compose deployment can be found here:
 # TBD
 
-version: '3'
+#version: '3'
 services:
   srv:
     image: "testrail/apache:${TESTRAIL_VERSION:-default}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@
 # Instructions for necessary settings during setup when using docker-compose deployment can be found here:
 # TBD
 
-#version: '3'
+version: '3'
 services:
   srv:
     image: "testrail/apache:${TESTRAIL_VERSION:-default}"

--- a/docker-compose_documented.yml
+++ b/docker-compose_documented.yml
@@ -94,7 +94,7 @@ services:
     volumes:
       - 'testrail_mysql:/var/lib/mysql'
     
-    # For TestRail versions supporting Chrome-based PDF generation, you can mount the folder containing the chromium binary as follows
+    # For TestRail versions supporting Chrome-based PDF generation, you can mount the folder containing the chrome binary as follows
     # - ./chrome-headless-shell-linux64:/usr/bin/chrome-headless-shell-linux64
 
     # With these environment variables, the database is initialized upon its first start.

--- a/docker-compose_documented.yml
+++ b/docker-compose_documented.yml
@@ -94,7 +94,7 @@ services:
     volumes:
       - 'testrail_mysql:/var/lib/mysql'
     
-    # For Testrail versions supporting Chromium-based PDF generation, you can mount the folder containing the chromium binary as follows
+    # For TestRail versions supporting Chrome-based PDF generation, you can mount the folder containing the chromium binary as follows
     # - ./chrome-headless-shell-linux64:/usr/bin/chrome-headless-shell-linux64
 
     # With these environment variables, the database is initialized upon its first start.

--- a/docker-compose_documented.yml
+++ b/docker-compose_documented.yml
@@ -93,6 +93,9 @@ services:
     # See volumes mapping below
     volumes:
       - 'testrail_mysql:/var/lib/mysql'
+    
+    # For Testrail versions supporting Chromium-based PDF generation, you can mount the folder containing the chromium binary as follows
+    # - ./chrome-headless-shell-linux64:/usr/bin/chrome-headless-shell-linux64
 
     # With these environment variables, the database is initialized upon its first start.
     # A database and a user with password are automatically created. The user is assigned full access rights to the created database.

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -7,7 +7,7 @@ echo
 echo " This script will help you to quickly start a TestRail instance and will"
 echo " populate a '.env' file with the necessary configuration values."
 echo " For more advanced configuration please directly modify the .env file and utilize"
-echo " docker-compose directly."
+echo " docker-compose/docker compose directly."
 
 echo
 echo " Please be aware that you will need 'sudo' installed to run this script."
@@ -39,7 +39,7 @@ mkdir -p  $backupDir
 if [ -n "${dockerPSOutput}" ];
 then
     echo " ### Seems like a TestRail instance is already running"
-    echo "   To shut it down run 'docker-compose down -v' in this folder and then call this script again."
+    echo "   To shut it down run 'docker-compose/docker compose down -v' in this folder and then call this script again."
     echo
     read -n1 -r -p "   Press 'c' to continue or any other key to abort..." key
 
@@ -176,8 +176,16 @@ fi
 echo
 echo "TestRail will be started now with HTTP and will listen on port ${httpPort}."
 
+if command -v docker-compose &> /dev/null; then
+    DOCKER_COMPOSE="docker-compose"
+elif docker compose version &> /dev/null; then
+    DOCKER_COMPOSE="docker compose"
+else
+    echo "Neither 'docker-compose' nor 'docker compose' is available."
+    exit 1
+fi
 
-docker-compose -f "${dockerComposeFile}" up -d
+$DOCKER_COMPOSE -f "${dockerComposeFile}" up -d
 sleep 5
 
 echo
@@ -230,4 +238,4 @@ echo "  The TestRail background task is also automatically started 60s after the
 echo
 echo
 echo "To shut down TestRail again run the following command in this folder:"
-echo "docker-compose down -v"
+echo "docker-compose/docker compose down -v"

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -223,7 +223,7 @@ echo "    User:       'cassandra'"
 echo "    Password:   'cassandra'"
 
 echo
-echo " CHROMIUM PATH (For Testrail versions that supports Chromium-based PDF Generation)"
+echo " CHROMIUM PATH (For TestRail versions that supports Chromium-based PDF Generation)"
 echo "    Chromium Headless Shell Path:     '/usr/bin/chrome-headless-shell-linux64/chrome-headless-shell'"
 
 echo

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -176,6 +176,7 @@ fi
 echo
 echo "TestRail will be started now with HTTP and will listen on port ${httpPort}."
 
+
 docker-compose -f "${dockerComposeFile}" up -d
 sleep 5
 

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -223,8 +223,8 @@ echo "    User:       'cassandra'"
 echo "    Password:   'cassandra'"
 
 echo
-echo " CHROMIUM PATH (For TestRail versions that supports Chromium-based PDF Generation)"
-echo "    Chromium Headless Shell Path:     '/usr/bin/chrome-headless-shell-linux64/chrome-headless-shell'"
+echo " CHROME PATH (For TestRail versions that supports Chrome-based PDF Generation)"
+echo "    Chrome Headless Shell Path:     '/usr/bin/chrome-headless-shell-linux64/chrome-headless-shell'"
 
 echo
 echo "  Application Settings"

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -7,7 +7,7 @@ echo
 echo " This script will help you to quickly start a TestRail instance and will"
 echo " populate a '.env' file with the necessary configuration values."
 echo " For more advanced configuration please directly modify the .env file and utilize"
-echo " docker-compose/docker compose directly."
+echo " docker-compose directly."
 
 echo
 echo " Please be aware that you will need 'sudo' installed to run this script."
@@ -39,7 +39,7 @@ mkdir -p  $backupDir
 if [ -n "${dockerPSOutput}" ];
 then
     echo " ### Seems like a TestRail instance is already running"
-    echo "   To shut it down run 'docker-compose/docker compose down -v' in this folder and then call this script again."
+    echo "   To shut it down run 'docker-compose -v' in this folder and then call this script again."
     echo
     read -n1 -r -p "   Press 'c' to continue or any other key to abort..." key
 
@@ -176,16 +176,7 @@ fi
 echo
 echo "TestRail will be started now with HTTP and will listen on port ${httpPort}."
 
-if command -v docker-compose &> /dev/null; then
-    DOCKER_COMPOSE="docker-compose"
-elif docker compose version &> /dev/null; then
-    DOCKER_COMPOSE="docker compose"
-else
-    echo "Neither 'docker-compose' nor 'docker compose' is available."
-    exit 1
-fi
-
-$DOCKER_COMPOSE -f "${dockerComposeFile}" up -d
+docker-compose -f "${dockerComposeFile}" up -d
 sleep 5
 
 echo
@@ -242,4 +233,4 @@ echo "  The TestRail background task is also automatically started 60s after the
 echo
 echo
 echo "To shut down TestRail again run the following command in this folder:"
-echo "docker-compose/docker compose down -v"
+echo "docker-compose down -v"

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -39,7 +39,7 @@ mkdir -p  $backupDir
 if [ -n "${dockerPSOutput}" ];
 then
     echo " ### Seems like a TestRail instance is already running"
-    echo "   To shut it down run 'docker-compose -v' in this folder and then call this script again."
+    echo "   To shut it down run 'docker-compose down -v' in this folder and then call this script again."
     echo
     read -n1 -r -p "   Press 'c' to continue or any other key to abort..." key
 

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -231,6 +231,10 @@ echo "    User:       'cassandra'"
 echo "    Password:   'cassandra'"
 
 echo
+echo " CHROMIUM PATH (For Testrail versions that supports Chromium-based PDF Generation)"
+echo "    Chromium Headless Shell Path:     '/usr/bin/chrome-headless-shell-linux64/chrome-headless-shell'"
+
+echo
 echo "  Application Settings"
 echo "    - Simply leave the default values for the folders 'logs, reports, attachments and audit'."
 echo


### PR DESCRIPTION
- Added headless chrome binary installation on sample Dockerfile for testrail.
- Updated quickstart.sh and docker-compose-documented to also guide users when installing Testrail versions with support for chromium-based PDF generation
- Added environment variable for chromium path for installation