### PR TITLE
Task/arch 264

### DIFF
--- a/Dockerfiles/testrail_apache/Dockerfile
+++ b/Dockerfiles/testrail_apache/Dockerfile
@@ -139,6 +139,9 @@ COPY apache_testrail.conf /apache-conf/000-default.conf
 COPY ssl_apache_testrail.conf /apache-conf/ssl_apache_testrail.conf
 COPY .htaccess /apache-conf/.htaccess
 
+RUN echo '<FilesMatch "\.(sql|ini)$">\n    Require all denied\n</FilesMatch>' > /var/www/testrail/.htaccess
+RUN chmod 644 /var/www/testrail/.htaccess
+
 COPY custom-entrypoint.sh /custom-entrypoint.sh
 ENTRYPOINT ["/custom-entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/Dockerfiles/testrail_apache/apache_testrail.conf
+++ b/Dockerfiles/testrail_apache/apache_testrail.conf
@@ -4,6 +4,12 @@
         ServerAdmin webmaster@localhost
         DocumentRoot /var/www/testrail
 
+        <Directory /var/www/testrail>
+                Options Indexes FollowSymLinks
+                AllowOverride All
+                Require all granted
+        </Directory>
+
         ErrorLog ${APACHE_LOG_DIR}/error.log
         CustomLog ${APACHE_LOG_DIR}/access.log combined
 </VirtualHost>


### PR DESCRIPTION
this changes are added to deny access .ini and .sql files from the web for docker customers.
for non-docker customers, we will provide updated documentation, how to do same.